### PR TITLE
added cancel api for likes

### DIFF
--- a/likes/api/serializers.py
+++ b/likes/api/serializers.py
@@ -15,7 +15,7 @@ class LikeSerializer(serializers.ModelSerializer):
         fields = ('user', 'created_at')
 
 
-class LikeSerializerForCreate(serializers.ModelSerializer):
+class BaseLikeSerializerForCreateAndCancel(serializers.ModelSerializer):
     content_type = serializers.ChoiceField(choices=['comment', 'tweet'])
     object_id = serializers.IntegerField()
 
@@ -39,6 +39,8 @@ class LikeSerializerForCreate(serializers.ModelSerializer):
             raise ValidationError({'object_id': 'Object does not exist'})
         return data
 
+class LikeSerializerForCreate(BaseLikeSerializerForCreateAndCancel):
+
     def create(self, validated_data):
         model_class = self._get_model_class(validated_data)
         instance, _ = Like.objects.get_or_create(
@@ -47,3 +49,17 @@ class LikeSerializerForCreate(serializers.ModelSerializer):
             user=self.context['request'].user,
         )
         return instance
+
+class LikeSerializerForCancel(BaseLikeSerializerForCreateAndCancel):
+
+    def cancel(self):
+        """
+        cancel is a self defined method, so it won't be called when serializer.save is called.
+        So we have to to serializer.cancel() to call it.
+        """
+        model_class = self._get_model_class(self.validated_data)
+        Like.objects.filter(
+            content_type=ContentType.objects.get_for_model(model_class),
+            object_id=self.validated_data['object_id'],
+            user=self.context['request'].user,
+        ).delete()

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -2,6 +2,8 @@ from testing.testcases import TestCase
 
 
 LIKE_BASE_URL = '/api/likes/'
+LIKE_CANCEL_URL = '/api/likes/cancel/'
+
 
 
 class LikeApiTests(TestCase):
@@ -73,3 +75,60 @@ class LikeApiTests(TestCase):
         self.assertEqual(comment.like_set.count(), 1)
         self.dongxie_client.post(LIKE_BASE_URL, data)
         self.assertEqual(comment.like_set.count(), 2)
+
+
+    def test_cancel(self):
+        tweet = self.create_tweet(self.linghu)
+        comment = self.create_comment(self.dongxie, tweet)
+        like_comment_data = {'content_type': 'comment', 'object_id': comment.id}
+        like_tweet_data = {'content_type': 'tweet', 'object_id': tweet.id}
+        self.linghu_client.post(LIKE_BASE_URL, like_comment_data)
+        self.dongxie_client.post(LIKE_BASE_URL, like_tweet_data)
+        self.assertEqual(tweet.like_set.count(), 1)
+        self.assertEqual(comment.like_set.count(), 1)
+
+        # login required
+        response = self.anonymous_client.post(LIKE_CANCEL_URL, like_comment_data)
+        self.assertEqual(response.status_code, 403)
+
+        # get is not allowed
+        response = self.linghu_client.get(LIKE_CANCEL_URL, like_comment_data)
+        self.assertEqual(response.status_code, 405)
+
+        # wrong content_type
+        response = self.linghu_client.post(LIKE_CANCEL_URL, {
+            'content_type': 'wrong',
+            'object_id': 1,
+        })
+        self.assertEqual(response.status_code, 400)
+
+        # wrong object_id
+        response = self.linghu_client.post(LIKE_CANCEL_URL, {
+            'content_type': 'comment',
+            'object_id': -1,
+        })
+        self.assertEqual(response.status_code, 400)
+
+        # dongxie has not liked before
+        response = self.dongxie_client.post(LIKE_CANCEL_URL, like_comment_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(tweet.like_set.count(), 1)
+        self.assertEqual(comment.like_set.count(), 1)
+
+        # successfully canceled
+        response = self.linghu_client.post(LIKE_CANCEL_URL, like_comment_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(tweet.like_set.count(), 1)
+        self.assertEqual(comment.like_set.count(), 0)
+
+        # linghu has not liked before
+        response = self.linghu_client.post(LIKE_CANCEL_URL, like_tweet_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(tweet.like_set.count(), 1)
+        self.assertEqual(comment.like_set.count(), 0)
+
+        # dongxie's like has been canceled
+        response = self.dongxie_client.post(LIKE_CANCEL_URL, like_tweet_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(tweet.like_set.count(), 0)
+        self.assertEqual(comment.like_set.count(), 0)

--- a/likes/api/views.py
+++ b/likes/api/views.py
@@ -1,12 +1,15 @@
 from likes.api.serializers import (
     LikeSerializer,
     LikeSerializerForCreate,
+    LikeSerializerForCancel,
 )
 from likes.models import Like
 from rest_framework import viewsets, status
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from utils.decorators import required_params
+
 
 
 class LikeViewSet(viewsets.GenericViewSet):
@@ -30,3 +33,18 @@ class LikeViewSet(viewsets.GenericViewSet):
             LikeSerializer(instance).data,
             status=status.HTTP_201_CREATED,
         )
+
+    @action(methods=['POST'], detail=False)
+    @required_params(request_attr='data', params=['content_type', 'object_id'])
+    def cancel(self, request, *args, **kwargs):
+        serializer = LikeSerializerForCancel(
+            data=request.data,
+            context={'request': request},
+        )
+        if not serializer.is_valid():
+            return Response({
+                'message': 'Please check input',
+                'errors': serializer.errors,
+            }, status=status.HTTP_400_BAD_REQUEST)
+        serializer.cancel()
+        return Response({'success': True}, status=status.HTTP_200_OK)


### PR DESCRIPTION
The reason why didn't use Delete /api/likes/<like_id> is because this could cause some problem when interact with front end. (Front end must know the like_id to delete). But sometimes the user click really quick. Delete might arrive earlier than Post. In this case, we do not know the like_id. 

Here, we use POST /api/likes/cancel/ to delete. No need to know the like_id.
POST /api/likes for create likes
POST /api/likes/cancel to delete likes.
