### PR TITLE
injected likes to other apps including comments, tweet, newsfeeds

### DIFF
--- a/comments/api/serializers.py
+++ b/comments/api/serializers.py
@@ -1,5 +1,6 @@
 from accounts.api.serializers import UserSerializerForComment
 from comments.models import Comment
+from likes.services import LikeService
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from tweets.models import Tweet
@@ -7,6 +8,8 @@ from tweets.models import Tweet
 
 class CommentSerializer(serializers.ModelSerializer):
     user = UserSerializerForComment()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
@@ -16,8 +19,15 @@ class CommentSerializer(serializers.ModelSerializer):
             'user',
             'content',
             'created_at',
-            'updated_at'
+            'likes_count',
+            'has_liked',
         )
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
 
 
 class CommentSerializerForCreate(serializers.ModelSerializer):

--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -5,7 +5,9 @@ from testing.testcases import TestCase
 from testing.testcases import TestCase
 
 COMMENT_URL = '/api/comments/'
-
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 class CommentApiTests(TestCase):
 
@@ -54,84 +56,106 @@ class CommentApiTests(TestCase):
         self.assertEqual(response.data['tweet_id'], self.tweet.id)
         self.assertEqual(response.data['content'], '1')
 
-        def test_destroy(self):
-            comment = self.create_comment(self.linghu, self.tweet)
-            url = '{}{}/'.format(COMMENT_URL, comment.id)
+    def test_destroy(self):
+        comment = self.create_comment(self.linghu, self.tweet)
+        url = '{}{}/'.format(COMMENT_URL, comment.id)
 
-            # 匿名不可以删除
-            response = self.anonymous_client.delete(url)
-            self.assertEqual(response.status_code, 403)
+        # 匿名不可以删除
+        response = self.anonymous_client.delete(url)
+        self.assertEqual(response.status_code, 403)
 
-            # 非本人不能删除
-            response = self.dongxie_client.delete(url)
-            self.assertEqual(response.status_code, 403)
+        # 非本人不能删除
+        response = self.dongxie_client.delete(url)
+        self.assertEqual(response.status_code, 403)
 
-            # 本人可以删除
-            count = Comment.objects.count()
-            response = self.linghu_client.delete(url)
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(Comment.objects.count(), count - 1)
+        # 本人可以删除
+        count = Comment.objects.count()
+        response = self.linghu_client.delete(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Comment.objects.count(), count - 1)
 
-        def test_update(self):
-            comment = self.create_comment(self.linghu, self.tweet, 'original')
-            another_tweet = self.create_tweet(self.dongxie)
-            url = '{}{}/'.format(COMMENT_URL, comment.id)
+    def test_update(self):
+        comment = self.create_comment(self.linghu, self.tweet, 'original')
+        another_tweet = self.create_tweet(self.dongxie)
+        url = '{}{}/'.format(COMMENT_URL, comment.id)
 
-            # 使用 put 的情况下
-            # 匿名不可以更新
-            response = self.anonymous_client.put(url, {'content': 'new'})
-            self.assertEqual(response.status_code, 403)
-            # 非本人不能更新
-            response = self.dongxie_client.put(url, {'content': 'new'})
-            self.assertEqual(response.status_code, 403)
-            comment.refresh_from_db()
-            self.assertNotEqual(comment.content, 'new')
-            # 不能更新除 content 外的内容，静默处理，只更新内容
-            before_updated_at = comment.updated_at
-            before_created_at = comment.created_at
-            now = timezone.now()
-            response = self.linghu_client.put(url, {
-                'content': 'new',
-                'user_id': self.dongxie.id,
-                'tweet_id': another_tweet.id,
-                'created_at': now,
-            })
-            self.assertEqual(response.status_code, 200)
-            comment.refresh_from_db()
-            self.assertEqual(comment.content, 'new')
-            self.assertEqual(comment.user, self.linghu)
-            self.assertEqual(comment.tweet, self.tweet)
-            self.assertEqual(comment.created_at, before_created_at)
-            self.assertNotEqual(comment.created_at, now)
-            self.assertNotEqual(comment.updated_at, before_updated_at)
+        # 使用 put 的情况下
+        # 匿名不可以更新
+        response = self.anonymous_client.put(url, {'content': 'new'})
+        self.assertEqual(response.status_code, 403)
+        # 非本人不能更新
+        response = self.dongxie_client.put(url, {'content': 'new'})
+        self.assertEqual(response.status_code, 403)
+        comment.refresh_from_db()
+        self.assertNotEqual(comment.content, 'new')
+        # 不能更新除 content 外的内容，静默处理，只更新内容
+        before_updated_at = comment.updated_at
+        before_created_at = comment.created_at
+        now = timezone.now()
+        response = self.linghu_client.put(url, {
+            'content': 'new',
+            'user_id': self.dongxie.id,
+            'tweet_id': another_tweet.id,
+            'created_at': now,
+        })
+        self.assertEqual(response.status_code, 200)
+        comment.refresh_from_db()
+        self.assertEqual(comment.content, 'new')
+        self.assertEqual(comment.user, self.linghu)
+        self.assertEqual(comment.tweet, self.tweet)
+        self.assertEqual(comment.created_at, before_created_at)
+        self.assertNotEqual(comment.created_at, now)
+        self.assertNotEqual(comment.updated_at, before_updated_at)
 
-            def test_list(self):
-                # 必须带 tweet_id
-                response = self.anonymous_client.get(COMMENT_URL)
-                self.assertEqual(response.status_code, 400)
+    def test_list(self):
+        # 必须带 tweet_id
+        response = self.anonymous_client.get(COMMENT_URL)
+        self.assertEqual(response.status_code, 400)
 
-                # 带了 tweet_id 可以访问
-                # 一开始没有评论
-                response = self.anonymous_client.get(COMMENT_URL, {
-                    'tweet_id': self.tweet.id,
-                })
-                self.assertEqual(response.status_code, 200)
-                self.assertEqual(len(response.data['comments']), 0)
+        # 带了 tweet_id 可以访问
+        # 一开始没有评论
+        response = self.anonymous_client.get(COMMENT_URL, {
+            'tweet_id': self.tweet.id,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['comments']), 0)
 
-                # 评论按照时间顺序排序
-                self.create_comment(self.linghu, self.tweet, '1')
-                self.create_comment(self.dongxie, self.tweet, '2')
-                self.create_comment(self.dongxie, self.create_tweet(self.dongxie), '3')
-                response = self.anonymous_client.get(COMMENT_URL, {
-                    'tweet_id': self.tweet.id,
-                })
-                self.assertEqual(len(response.data['comments']), 2)
-                self.assertEqual(response.data['comments'][0]['content'], '1')
-                self.assertEqual(response.data['comments'][1]['content'], '2')
+        # 评论按照时间顺序排序
+        self.create_comment(self.linghu, self.tweet, '1')
+        self.create_comment(self.dongxie, self.tweet, '2')
+        self.create_comment(self.dongxie, self.create_tweet(self.dongxie), '3')
+        response = self.anonymous_client.get(COMMENT_URL, {
+            'tweet_id': self.tweet.id,
+        })
+        self.assertEqual(len(response.data['comments']), 2)
+        self.assertEqual(response.data['comments'][0]['content'], '1')
+        self.assertEqual(response.data['comments'][1]['content'], '2')
 
-                # 同时提供 user_id 和 tweet_id 只有 tweet_id 会在 filter 中生效
-                response = self.anonymous_client.get(COMMENT_URL, {
-                    'tweet_id': self.tweet.id,
-                    'user_id': self.linghu.id,
-                })
-                self.assertEqual(len(response.data['comments']), 2)
+        # 同时提供 user_id 和 tweet_id 只有 tweet_id 会在 filter 中生效
+        response = self.anonymous_client.get(COMMENT_URL, {
+            'tweet_id': self.tweet.id,
+            'user_id': self.linghu.id,
+        })
+        self.assertEqual(len(response.data['comments']), 2)
+
+
+    def test_comments_count(self):
+        # test tweet detail api
+        tweet = self.create_tweet(self.linghu)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments_count'], 0)
+
+        # test tweet list api
+        self.create_comment(self.linghu, tweet)
+        response = self.dongxie_client.get(TWEET_LIST_API, {'user_id': self.linghu.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['tweets'][0]['comments_count'], 1)
+
+        # test newsfeeds list api
+        self.create_comment(self.dongxie, tweet)
+        self.create_newsfeed(self.dongxie, tweet)
+        response = self.dongxie_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['comments_count'], 2)

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -35,7 +35,11 @@ class CommentViewSet(viewsets.GenericViewSet):
         comments = self.filter_queryset(queryset)\
             .prefetch_related('user')\
             .order_by('created_at')
-        serializer = CommentSerializer(comments, many=True)
+        serializer = CommentSerializer(
+            comments,
+            context={'request': request},
+            many=True,
+        )
         return Response(
             {'comments': serializer.data},
             status=status.HTTP_200_OK,
@@ -59,7 +63,7 @@ class CommentViewSet(viewsets.GenericViewSet):
         # save 方法会触发 serializer 里的 create 方法，点进 save 的具体实现里可以看到
         comment = serializer.save()
         return Response(
-            CommentSerializer(comment).data,
+            CommentSerializer(comment, context={'request': request}).data,
             status=status.HTTP_201_CREATED,
         )
 
@@ -80,7 +84,7 @@ class CommentViewSet(viewsets.GenericViewSet):
         # save 是根据 instance 参数有没有传来决定是触发 create 还是 update
         comment = serializer.save()
         return Response(
-            CommentSerializer(comment).data,
+            CommentSerializer(comment, context={'request': request}).data,
             status=status.HTTP_200_OK,
         )
 

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -1,9 +1,13 @@
 from testing.testcases import TestCase
+from rest_framework.test import APIClient
 
 
 LIKE_BASE_URL = '/api/likes/'
 LIKE_CANCEL_URL = '/api/likes/cancel/'
-
+COMMENT_LIST_API = '/api/comments/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 
 class LikeApiTests(TestCase):
@@ -132,3 +136,68 @@ class LikeApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(tweet.like_set.count(), 0)
         self.assertEqual(comment.like_set.count(), 0)
+
+
+    def test_likes_in_comments_api(self):
+        tweet = self.create_tweet(self.linghu)
+        comment = self.create_comment(self.linghu, tweet)
+
+        # test anonymous
+        anonymous_client = APIClient()
+        response = anonymous_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+
+        # test comments list api
+        response = self.dongxie_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+        self.create_like(self.dongxie, comment)
+        response = self.dongxie_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 1)
+
+        # test tweet detail api
+        self.create_like(self.linghu, comment)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 2)
+
+    def test_likes_in_tweets_api(self):
+        tweet = self.create_tweet(self.linghu)
+
+        # test tweet detail api
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['has_liked'], False)
+        self.assertEqual(response.data['likes_count'], 0)
+        self.create_like(self.dongxie, tweet)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(response.data['has_liked'], True)
+        self.assertEqual(response.data['likes_count'], 1)
+
+        # test tweets list api
+        response = self.dongxie_client.get(TWEET_LIST_API, {'user_id': self.linghu.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['tweets'][0]['has_liked'], True)
+        self.assertEqual(response.data['tweets'][0]['likes_count'], 1)
+
+        # test newsfeeds list api
+        self.create_like(self.linghu, tweet)
+        self.create_newsfeed(self.dongxie, tweet)
+        response = self.dongxie_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['has_liked'], True)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['likes_count'], 2)
+
+        # test likes details
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.dongxie_client.get(url)
+        self.assertEqual(len(response.data['likes']), 2)
+        self.assertEqual(response.data['likes'][0]['user']['id'], self.linghu.id)
+        self.assertEqual(response.data['likes'][1]['user']['id'], self.dongxie.id)

--- a/likes/services.py
+++ b/likes/services.py
@@ -1,0 +1,15 @@
+from likes.models import Like
+from django.contrib.contenttypes.models import ContentType
+
+
+class LikeService(object):
+
+    @classmethod
+    def has_liked(cls, user, target):
+        if user.is_anonymous:
+            return False
+        return Like.objects.filter(
+            content_type=ContentType.objects.get_for_model(target.__class__),
+            object_id=target.id,
+            user=user,
+        ).exists()

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -16,7 +16,11 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         return NewsFeed.objects.filter(user=self.request.user)
 
     def list(self, request):
-        serializer = NewsFeedSerializer(self.get_queryset(), many=True)
+        serializer = NewsFeedSerializer(
+            self.get_queryset(),
+            context={'request': request},
+            many=True,
+        )
         return Response({
             'newsfeeds': serializer.data,
         }, status=status.HTTP_200_OK)

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase as DjangoTestCase
 from likes.models import Like
+from newsfeeds.models import NewsFeed
 from rest_framework.test import APIClient
 from tweets.models import Tweet
 
@@ -42,6 +43,9 @@ class TestCase(DjangoTestCase):
             user=user,
         )
         return instance
+
+    def create_newsfeed(self, user, tweet):
+        return NewsFeed.objects.create(user=user, tweet=tweet)
 
     def create_user_and_client(self, *args, **kwargs):
         user = self.create_user(*args, **kwargs)

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,14 +1,35 @@
 from accounts.api.serializers import UserSerializerForTweet, UserSerializer
 from comments.api.serializers import CommentSerializer
+from likes.api.serializers import LikeSerializer
+from likes.services import LikeService
 from rest_framework import serializers
 from tweets.models import Tweet
 
 class TweetSerializer(serializers.ModelSerializer):
     user = UserSerializerForTweet()
+    comments_count = serializers.SerializerMethodField()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'created_at', 'content')
+        fields = (
+            'id',
+            'user',
+            'created_at',
+            'content',
+            'comments_count',
+            'likes_count',
+            'has_liked',
+        )
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+    def get_comments_count(self, obj):
+        return obj.comment_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
 
 
 class TweetSerializerForCreate(serializers.ModelSerializer):
@@ -24,13 +45,24 @@ class TweetSerializerForCreate(serializers.ModelSerializer):
         tweet = Tweet.objects.create(user=user, content=content)
         return tweet
 
-class TweetSerializerWithComments(serializers.ModelSerializer):
-    user = UserSerializer()
+class TweetSerializerForDetail(TweetSerializer):
     # could use serializers.SerializerMethodField to get comments as well.
     comments = CommentSerializer(source='comment_set', many=True)
+    likes = LikeSerializer(source='like_set', many=True)
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'comments', 'created_at', 'content')
+        fields = (
+            'id',
+            'user',
+            'comments',
+            'created_at',
+            'content',
+            'likes',
+            'comments',
+            'likes_count',
+            'comments_count',
+            'has_liked',
+        )
 
 

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -1,7 +1,11 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
-from tweets.api.serializers import TweetSerializer, TweetSerializerForCreate, TweetSerializerWithComments
+from tweets.api.serializers import (
+    TweetSerializer,
+    TweetSerializerForCreate,
+    TweetSerializerForDetail,
+)
 from tweets.models import Tweet
 from newsfeeds.services import NewsFeedService
 from utils.decorators import required_params
@@ -25,12 +29,19 @@ class TweetViewSet(viewsets.GenericViewSet):
             user_id=request.query_params['user_id']
         ).order_by('-created_at')
         # many=True会返回一个list of dict
-        serializer = TweetSerializer(tweets, many=True)
+        serializer = TweetSerializer(
+            tweets,
+            context={'request': request},
+            many=True,
+        )
         return Response({'tweets': serializer.data})
 
     def retrieve(self, request, *args, **kwargs):
-        tweet = self.get_object()
-        return Response(TweetSerializerWithComments(tweet).data)
+        serializer = TweetSerializerForDetail(
+            self.get_object(),
+            context={'request': request},
+        )
+        return Response(serializer.data)
 
     def create(self, request):
         """
@@ -49,4 +60,5 @@ class TweetViewSet(viewsets.GenericViewSet):
         # save will call create method in TweetSerializerForCreate
         tweet = serializer.save()
         NewsFeedService.fanout_to_followers(tweet)
-        return Response(TweetSerializer(tweet).data, status=201)
+        serializer = TweetSerializer(tweet, context={'request': request})
+        return Response(serializer.data, status=201)


### PR DESCRIPTION
We need to know how many likes a comment, or a tweet have. Meanwhile, since newsfeeds serializer used tweet serializer and tweet serializer needs context parameter, therefore, we need to pass context parameter to tweet serializer in the view set, so the context parameter will be passed to newsfeeds serializer when the tweet serializer is called in the newsfeeds serializer. 